### PR TITLE
Model indexing fix in AlbumWidget::addPictures (chapter 4)

### DIFF
--- a/Chapter04/gallery-desktop/AlbumWidget.cpp
+++ b/Chapter04/gallery-desktop/AlbumWidget.cpp
@@ -136,6 +136,7 @@ void AlbumWidget::addPictures()
             Picture picture(filename);
             lastModelIndex = mPictureModel->pictureModel()->addPicture(picture);
         }
+        lastModelIndex = mPictureModel->index(lastModelIndex.row(), 0);
         ui->thumbnailListView->setCurrentIndex(lastModelIndex);
     }
 }


### PR DESCRIPTION
(This was originally submitted to the 1st edition's codebase <https://github.com/PacktPublishing/Mastering-Qt-5/pull/10> but also applies here)

Thanks for a great book, but while reading it I stumbled upon a problem I might even have a solution for.

When running Debug binary of gallery-desktop from chapter 4 the program shuts down on adding pictures, just after closing the "Open File" dialog, with a message:

> `ASSERT: "proxyIndex.model() == this" in file itemmodels\qidentityproxymodel.cpp, line 259`

The program runs just fine in Release.

The offending line is Qt sources is <https://github.com/qt/qtbase/blob/4eda22ea0db1fc571ae9f44a68825056e6245548/src/corelib/itemmodels/qidentityproxymodel.cpp#L259>

As I digged down, the problem seems to lay in `AlbumWidget::addPictures`. The `lastModelIndex` is an index into `PictureModel` but it is used later to `setCurrentIndex` where `ThumbnailProxyModel` is expected.

The simplest fix might be just adding a line converting the `QModelIndex` (below).

*Works on my machine* ;-)

My environment is Qt 5.12.1 on MinGW 64bit but it seems to be platform agnostic.